### PR TITLE
Update dependencies and bump version to 1.3.3

### DIFF
--- a/AppSnackBar-UiState/README.md
+++ b/AppSnackBar-UiState/README.md
@@ -13,9 +13,9 @@ Integration module that bridges the AppSnackBar and UiState modules, providing a
 
 ```gradle.kts
 // Requires both base modules
-implementation("com.github.appoly.AppolyDroid-Toolbox:UiState:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar-UiState:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:UiState:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar-UiState:1.3.3")
 ```
 
 ## Usage

--- a/AppSnackBar/README.md
+++ b/AppSnackBar/README.md
@@ -13,7 +13,7 @@ A customizable Jetpack Compose Snackbar implementation with support for differen
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar:1.3.3")
 ```
 
 ## Usage

--- a/BaseRepo-AppolyJson/README.md
+++ b/BaseRepo-AppolyJson/README.md
@@ -14,8 +14,8 @@ Appoly's JSON format.
 
 ```gradle.kts
 // Requires the base BaseRepo module
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-AppolyJson:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-AppolyJson:1.3.3")
 ```
 
 ## API Response Structure

--- a/BaseRepo-Paging-AppolyJson/README.md
+++ b/BaseRepo-Paging-AppolyJson/README.md
@@ -15,13 +15,13 @@ follow Appoly's paging format.
 
 ```gradle.kts
 // Requires the base modules
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging-AppolyJson:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging-AppolyJson:1.3.3")
 
 // For Compose UI integration
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.3.2") // For LazyColumn
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.3.2") // For LazyGrid
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.3.3") // For LazyColumn
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.3.3") // For LazyGrid
 ```
 
 ## API Response Format

--- a/BaseRepo-Paging/README.md
+++ b/BaseRepo-Paging/README.md
@@ -17,12 +17,12 @@ extended for specific JSON formats.
 
 ```gradle.kts
 // Requires the base BaseRepo module
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging:1.3.3")
 
 // For Compose UI integration
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.3.2") // For LazyColumn
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.3.2") // For LazyGrid
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.3.3") // For LazyColumn
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.3.3") // For LazyGrid
 ```
 
 ## Extensions

--- a/BaseRepo-S3Uploader-Multipart/README.md
+++ b/BaseRepo-S3Uploader-Multipart/README.md
@@ -15,9 +15,9 @@ Extension module that bridges BaseRepo and S3Uploader-Multipart, enabling pausab
 
 ```gradle.kts
 // Requires the base modules
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader-Multipart:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-S3Uploader-Multipart:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader-Multipart:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-S3Uploader-Multipart:1.3.3")
 ```
 
 ## Usage

--- a/BaseRepo-S3Uploader/README.md
+++ b/BaseRepo-S3Uploader/README.md
@@ -18,9 +18,9 @@ An extension module that bridges BaseRepo and S3Uploader, enabling seamless file
 
 ```gradle.kts
 // Requires both the base modules
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-S3Uploader:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-S3Uploader:1.3.3")
 ```
 
 ## How it Works

--- a/BaseRepo/README.md
+++ b/BaseRepo/README.md
@@ -14,7 +14,7 @@ Foundation module for implementing the repository pattern with standardized API 
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.3.3")
 ```
 
 ## Extensions

--- a/ConnectivityMonitor/README.md
+++ b/ConnectivityMonitor/README.md
@@ -9,7 +9,7 @@
 Add the following dependency to your project's `build.gradle` file:
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:connectivitymonitor:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:connectivitymonitor:1.3.3")
 ```
 
 ## Usage

--- a/DateHelperUtil-Room/README.md
+++ b/DateHelperUtil-Room/README.md
@@ -15,8 +15,8 @@ Extension module for DateHelperUtil that provides Room database integration for 
 
 ```gradle.kts
 // Requires base DateHelperUtil module
-implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil-Room:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil-Room:1.3.3")
 
 // Required Room dependencies
 implementation("androidx.room:room-runtime:2.8.4")

--- a/DateHelperUtil-Serialization/README.md
+++ b/DateHelperUtil-Serialization/README.md
@@ -15,8 +15,8 @@ Extension module for DateHelperUtil that provides kotlinx.serialization integrat
 
 ```gradle.kts
 // Requires base DateHelperUtil module
-implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil-Serialization:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil-Serialization:1.3.3")
 
 // Required kotlinx.serialization dependencies
 implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0")

--- a/DateHelperUtil/README.md
+++ b/DateHelperUtil/README.md
@@ -13,7 +13,7 @@ A utility module for standardized date and time operations in Android applicatio
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.3.3")
 ```
 
 ## Usage

--- a/LazyGridPagingExtensions/README.md
+++ b/LazyGridPagingExtensions/README.md
@@ -15,8 +15,8 @@ Extension functions for integrating Jetpack Paging 3 with Compose LazyVerticalGr
 
 ```gradle.kts
 // Requires the base PagingExtensions module
-implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.3.3")
 
 // Make sure to include Jetpack Paging Compose
 implementation("androidx.paging:paging-compose:3.4.2")

--- a/LazyListPagingExtensions/README.md
+++ b/LazyListPagingExtensions/README.md
@@ -15,8 +15,8 @@ Extension functions for easy integration of Jetpack Paging 3 with Compose LazyCo
 
 ```gradle.kts
 // Requires the base PagingExtensions module
-implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.3.2")
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.3.3")
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.3.3")
 
 // Make sure to include Jetpack Paging Compose
 implementation("androidx.paging:paging-compose:3.4.2")

--- a/MockInterceptor-AppolyJson/README.md
+++ b/MockInterceptor-AppolyJson/README.md
@@ -14,7 +14,7 @@ Extension for [MockInterceptor-Serialization](../MockInterceptor-Serialization/)
 
 ```gradle.kts
 // MockInterceptor and MockInterceptor-Serialization are included transitively
-implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-AppolyJson:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-AppolyJson:1.3.3")
 ```
 
 ## Usage

--- a/MockInterceptor-Retrofit/README.md
+++ b/MockInterceptor-Retrofit/README.md
@@ -13,7 +13,7 @@ Extension for [MockInterceptor](../MockInterceptor/) that reads Retrofit HTTP an
 
 ```gradle.kts
 // MockInterceptor is included transitively
-implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-Retrofit:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-Retrofit:1.3.3")
 ```
 
 > **Note:** Retrofit is a `compileOnly` dependency — your project must already depend on Retrofit.

--- a/MockInterceptor-Serialization/README.md
+++ b/MockInterceptor-Serialization/README.md
@@ -12,7 +12,7 @@ Extension for [MockInterceptor](../MockInterceptor/) that adds type-safe JSON re
 
 ```gradle.kts
 // MockInterceptor is included transitively
-implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-Serialization:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-Serialization:1.3.3")
 ```
 
 ## Usage

--- a/MockInterceptor/README.md
+++ b/MockInterceptor/README.md
@@ -16,7 +16,7 @@ An OkHttp interceptor with a route-matching DSL for mocking API responses during
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor:1.3.3")
 ```
 
 ## Usage

--- a/PagingExtensions/README.md
+++ b/PagingExtensions/README.md
@@ -12,7 +12,7 @@ Core utilities and extensions for Jetpack Paging 3 integration, providing the fo
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.3.3")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In your `libs.versions.toml` file:
 
 ```toml
 [versions]
-appolydroidToolbox = "1.3.2" # Replace with the latest version
+appolydroidToolbox = "1.3.3" # Replace with the latest version
 
 [libraries]
 appolydroid-toolbox-bom = { group = "com.github.appoly.AppolyDroid-Toolbox", name = "AppolyDroid-Toolbox-bom", version.ref = "appolydroidToolbox" }
@@ -126,7 +126,7 @@ In your module's `build.gradle.kts`:
 ```gradle.kts
 dependencies {
     // Import the BOM
-    implementation(platform("com.github.appoly.AppolyDroid-Toolbox:AppolyDroid-Toolbox-bom:1.3.2"))
+    implementation(platform("com.github.appoly.AppolyDroid-Toolbox:AppolyDroid-Toolbox-bom:1.3.3"))
 
     // Now you can use AppolyDroid modules without specifying versions
     implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo")
@@ -162,7 +162,7 @@ In your `libs.versions.toml` file:
 
 ```toml
 [versions]
-appolydroidToolbox = "1.3.2" # Replace with the latest version
+appolydroidToolbox = "1.3.3" # Replace with the latest version
 
 [libraries]
 #AppolyDroid-Toolbox
@@ -228,7 +228,7 @@ In your module's `build.gradle.kts`:
 
 ```gradle.kts
 dependencies {
-    val appolydroidToolbox = "1.3.2" // Replace with the latest version
+    val appolydroidToolbox = "1.3.3" // Replace with the latest version
     // Add only the modules you need
     implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:$appolydroidToolbox")
     implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-AppolyJson:$appolydroidToolbox")

--- a/S3Uploader-Multipart/README.md
+++ b/S3Uploader-Multipart/README.md
@@ -16,7 +16,7 @@ Advanced S3 upload module with pause, resume, and recovery support using AWS S3 
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader-Multipart:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader-Multipart:1.3.3")
 ```
 
 This module depends on `S3Uploader` and includes it transitively.

--- a/S3Uploader-Multipart/build.gradle.kts
+++ b/S3Uploader-Multipart/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
     implementation(libs.androidx.work.runtime)
 
     // Coroutines
-    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime)
 
     // kotlinx serialization (for JSON storage)
     implementation(libs.kotlinx.serialization)

--- a/S3Uploader/README.md
+++ b/S3Uploader/README.md
@@ -16,7 +16,7 @@ Standalone module for Amazon S3 file uploading with progress tracking and error 
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader:1.3.3")
 ```
 
 ## Usage

--- a/SegmentedControl/README.md
+++ b/SegmentedControl/README.md
@@ -17,7 +17,7 @@ A highly customizable iOS-style segmented control for Jetpack Compose with smoot
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:SegmentedControl:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:SegmentedControl:1.3.3")
 ```
 
 ## Usage

--- a/UiState/README.md
+++ b/UiState/README.md
@@ -13,7 +13,7 @@ A standardized UI state management library for Android applications, providing c
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:UiState:1.3.2")
+implementation("com.github.appoly.AppolyDroid-Toolbox:UiState:1.3.3")
 ```
 
 ## Usage

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,7 @@ kotlin {
 dependencies {
 
 	implementation(libs.androidx.core.ktx)
-	implementation(libs.androidx.lifecycle.runtime.ktx)
+	implementation(libs.androidx.lifecycle.runtime)
 	implementation(libs.androidx.activity.compose)
 
 	//Compose

--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -9,14 +9,14 @@ object BuildConfig {
      * The current version of the AppolyDroid Toolbox library.
      * This is used for maven publishing and README version updates.
      */
-	const val TOOLBOX_VERSION = "1.3.2"
+	const val TOOLBOX_VERSION = "1.3.3"
 
     /**
      * SDK version configuration for Android modules.
      */
     object Sdk {
-        const val COMPILE = 36
-        const val TARGET = 36
+        const val COMPILE = 37
+        const val TARGET = 37
     }
 
     /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,23 @@
 [versions]
-agp = "9.1.1"
-kotlin = "2.3.20"
-ksp = "2.3.6"
+agp = "9.2.0"
+kotlin = "2.3.21"
+ksp = "2.3.7"
 coreKtx = "1.18.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-lifecycleRuntimeKtx = "2.10.0"
+lifecycleRuntime = "2.10.0"
 appcompat = "1.7.1"
 activityCompose = "1.13.0"
-composeBom = "2026.03.01"
-flexiLoggerVersion = "2.1.0"
+composeBom = "2026.04.01"
+flexiLoggerVersion = "2.1.1"
 okhttp = "5.3.2"
 retrofit = "3.0.0"
-sandwichVersion = "2.2.1"
+sandwichVersion = "2.2.2"
 kotlinxSerialization = "1.11.0"
 paging = "3.4.2"
 roomVersion = "2.8.4"
-navigationCompose = "2.9.7"
+navigationCompose = "2.9.8"
 workManager = "2.11.2"
 
 [libraries]
@@ -25,7 +25,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime", version.ref = "lifecycleRuntime" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 
 #Compose
@@ -79,7 +79,7 @@ androidx-room-testing = { group = "androidx.room", name = "room-testing", versio
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 
 #WorkManager
-androidx-work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workManager" }
+androidx-work-runtime = { group = "androidx.work", name = "work-runtime", version.ref = "workManager" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Apr 29 13:10:28 BST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- **AGP** 9.1.1 → 9.2.0, **Kotlin** 2.3.20 → 2.3.21, **KSP** 2.3.6 → 2.3.7
- **Compose BOM** 2026.03.01 → 2026.04.01, **Navigation Compose** 2.9.7 → 2.9.8, **Sandwich** 2.2.1 → 2.2.2, **FlexiLogger** 2.1.0 → 2.1.1
- **Gradle** 9.3.1 → 9.4.1, **compile/target SDK** 36 → 37
- Migrate `lifecycle-runtime-ktx` → `lifecycle-runtime` and `work-runtime-ktx` → `work-runtime` (the `-ktx` artifacts have been empty shims since 2.8.0 / 2.9.0, with all KTX APIs merged into the base artifact — no source changes needed)
- Bump toolbox version to 1.3.3 (READMEs auto-regenerated by `UpdateReadmeVersions`)

## Test plan
- [x] Gradle sync succeeds in Android Studio
- [ ] Demo `app` module builds and runs
- [ ] `./gradlew build` passes across all modules
- [ ] `./gradlew publishToMavenLocal` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)