### PR TITLE
DateHelperUtil 1.4.1 — restore short-format tolerance for server timestamps

### DIFF
--- a/AppSnackBar-UiState/README.md
+++ b/AppSnackBar-UiState/README.md
@@ -13,9 +13,9 @@ Integration module that bridges the AppSnackBar and UiState modules, providing a
 
 ```gradle.kts
 // Requires both base modules
-implementation("com.github.appoly.AppolyDroid-Toolbox:UiState:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar-UiState:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:UiState:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar-UiState:1.4.1")
 ```
 
 ## Usage

--- a/AppSnackBar/README.md
+++ b/AppSnackBar/README.md
@@ -13,7 +13,7 @@ A customizable Jetpack Compose Snackbar implementation with support for differen
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:AppSnackBar:1.4.1")
 ```
 
 ## Usage

--- a/BaseRepo-AppolyJson/README.md
+++ b/BaseRepo-AppolyJson/README.md
@@ -14,8 +14,8 @@ Appoly's JSON format.
 
 ```gradle.kts
 // Requires the base BaseRepo module
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-AppolyJson:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-AppolyJson:1.4.1")
 ```
 
 ## API Response Structure

--- a/BaseRepo-Paging-AppolyJson/README.md
+++ b/BaseRepo-Paging-AppolyJson/README.md
@@ -15,13 +15,13 @@ follow Appoly's paging format.
 
 ```gradle.kts
 // Requires the base modules
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging-AppolyJson:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging-AppolyJson:1.4.1")
 
 // For Compose UI integration
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.4.0") // For LazyColumn
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.4.0") // For LazyGrid
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.4.1") // For LazyColumn
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.4.1") // For LazyGrid
 ```
 
 ## API Response Format

--- a/BaseRepo-Paging/README.md
+++ b/BaseRepo-Paging/README.md
@@ -17,12 +17,12 @@ extended for specific JSON formats.
 
 ```gradle.kts
 // Requires the base BaseRepo module
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-Paging:1.4.1")
 
 // For Compose UI integration
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.4.0") // For LazyColumn
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.4.0") // For LazyGrid
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.4.1") // For LazyColumn
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.4.1") // For LazyGrid
 ```
 
 ## Extensions

--- a/BaseRepo-S3Uploader-Multipart/README.md
+++ b/BaseRepo-S3Uploader-Multipart/README.md
@@ -15,9 +15,9 @@ Extension module that bridges BaseRepo and S3Uploader-Multipart, enabling pausab
 
 ```gradle.kts
 // Requires the base modules
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader-Multipart:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-S3Uploader-Multipart:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader-Multipart:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-S3Uploader-Multipart:1.4.1")
 ```
 
 ## Usage

--- a/BaseRepo-S3Uploader/README.md
+++ b/BaseRepo-S3Uploader/README.md
@@ -18,9 +18,9 @@ An extension module that bridges BaseRepo and S3Uploader, enabling seamless file
 
 ```gradle.kts
 // Requires both the base modules
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-S3Uploader:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-S3Uploader:1.4.1")
 ```
 
 ## How it Works

--- a/BaseRepo/README.md
+++ b/BaseRepo/README.md
@@ -14,7 +14,7 @@ Foundation module for implementing the repository pattern with standardized API 
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:1.4.1")
 ```
 
 ## Extensions

--- a/ConnectivityMonitor/README.md
+++ b/ConnectivityMonitor/README.md
@@ -9,7 +9,7 @@
 Add the following dependency to your project's `build.gradle` file:
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:connectivitymonitor:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:connectivitymonitor:1.4.1")
 ```
 
 ## Usage

--- a/DateHelperUtil-Room/README.md
+++ b/DateHelperUtil-Room/README.md
@@ -16,8 +16,8 @@ Extension module for DateHelperUtil that provides Room database integration for 
 
 ```gradle.kts
 // Requires base DateHelperUtil module
-implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil-Room:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil-Room:1.4.1")
 
 // Required Room dependencies
 implementation("androidx.room:room-runtime:2.8.4")
@@ -164,7 +164,7 @@ The DateHelperUtil-Room module stores date-time values in the following formats:
 | ZonedDateTime | ISO-8601 extended format (UTC) | "2023-05-30T15:45:30.000000Z" |
 
 > [!IMPORTANT]
-> **Storage format change in 1.4.0** for `LocalDateTime` columns: writes now use the honest
+> **Storage format change in 1.4.1** for `LocalDateTime` columns: writes now use the honest
 > no-zone format (no trailing `Z`). Reads are fully backward-compatible — existing rows
 > with the legacy `...Z` suffix continue to parse correctly via `parseNaiveDateTime`'s
 > fallback chain. No Room migration required.

--- a/DateHelperUtil-Room/README.md
+++ b/DateHelperUtil-Room/README.md
@@ -164,7 +164,7 @@ The DateHelperUtil-Room module stores date-time values in the following formats:
 | ZonedDateTime | ISO-8601 extended format (UTC) | "2023-05-30T15:45:30.000000Z" |
 
 > [!IMPORTANT]
-> **Storage format change in 1.4.1** for `LocalDateTime` columns: writes now use the honest
+> **Storage format change in 1.4.0** for `LocalDateTime` columns: writes now use the honest
 > no-zone format (no trailing `Z`). Reads are fully backward-compatible — existing rows
 > with the legacy `...Z` suffix continue to parse correctly via `parseNaiveDateTime`'s
 > fallback chain. No Room migration required.

--- a/DateHelperUtil-Serialization/README.md
+++ b/DateHelperUtil-Serialization/README.md
@@ -16,8 +16,8 @@ Extension module for DateHelperUtil that provides kotlinx.serialization integrat
 
 ```gradle.kts
 // Requires base DateHelperUtil module
-implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil-Serialization:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil-Serialization:1.4.1")
 
 // Required kotlinx.serialization dependencies
 implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0")
@@ -151,7 +151,7 @@ The serializers use the standard date formats defined in DateHelper:
 | Instant | ISO-8601 datetime (UTC) | `"2025-06-15T13:00:00.000000Z"` |
 
 > [!IMPORTANT]
-> **Wire format change in 1.4.0** for `LocalDateTime` serialization: emitted JSON no longer
+> **Wire format change in 1.4.1** for `LocalDateTime` serialization: emitted JSON no longer
 > carries a trailing `Z`. The honest no-zone format reflects that `LocalDateTime` carries
 > no zone information.
 >

--- a/DateHelperUtil-Serialization/README.md
+++ b/DateHelperUtil-Serialization/README.md
@@ -151,7 +151,7 @@ The serializers use the standard date formats defined in DateHelper:
 | Instant | ISO-8601 datetime (UTC) | `"2025-06-15T13:00:00.000000Z"` |
 
 > [!IMPORTANT]
-> **Wire format change in 1.4.1** for `LocalDateTime` serialization: emitted JSON no longer
+> **Wire format change in 1.4.0** for `LocalDateTime` serialization: emitted JSON no longer
 > carries a trailing `Z`. The honest no-zone format reflects that `LocalDateTime` carries
 > no zone information.
 >

--- a/DateHelperUtil/README.md
+++ b/DateHelperUtil/README.md
@@ -27,9 +27,9 @@ backends were getting `DateTimeParseException` on every `created_at` / `updated_
 when bumping from 1.3.x straight to 1.4.0. 1.4.1 is the recommended baseline for the 1.4
 line; 1.4.0 should be avoided against any backend that emits zone-naive server timestamps.
 
-## Migrating from 1.3.x to 1.4.1
+## Migrating from 1.3.x to 1.4
 
-1.4.1 makes timezone semantics explicit at the type level. The summary:
+1.4.0 made timezone semantics explicit at the type level. The summary:
 
 ### What's new
 
@@ -158,7 +158,7 @@ val fileString = localDateTime.toFileString()
 ```
 
 > [!IMPORTANT]
-> **Wire format change in 1.4.1.** The naive format helpers (and any path routing through
+> **Wire format change in 1.4.0.** The naive format helpers (and any path routing through
 > them — `LocalDateTime.toJsonString()`, `DateTimeSerializer`, `localDateTimeToJson` Room
 > converter) now emit `2025-05-29T10:38:29.000000` (no `Z`) where pre-1.4 they emitted
 > `2025-05-29T10:38:29.000000Z`. The honest no-zone format reflects what `LocalDateTime`

--- a/DateHelperUtil/README.md
+++ b/DateHelperUtil/README.md
@@ -14,12 +14,22 @@ A utility module for standardized date and time operations in Android applicatio
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:DateHelperUtil:1.4.1")
 ```
 
-## Migrating from 1.3.x to 1.4.0
+## 1.4.1 patch note
 
-1.4.0 makes timezone semantics explicit at the type level. The summary:
+`parseServerInstant` and `parseServerZoneDateTime` (and therefore the
+`ZonedDateTimeSerializer` / `NullableZonedDateTimeSerializer` they back) now fall back to
+the short `yyyy-MM-dd HH:mm:ss` format, treating the digits as UTC. This restores the
+pre-1.4 tolerance that 1.4.0 inadvertently lost — apps consuming Carbon/Laravel-style
+backends were getting `DateTimeParseException` on every `created_at` / `updated_at` field
+when bumping from 1.3.x straight to 1.4.0. 1.4.1 is the recommended baseline for the 1.4
+line; 1.4.0 should be avoided against any backend that emits zone-naive server timestamps.
+
+## Migrating from 1.3.x to 1.4.1
+
+1.4.1 makes timezone semantics explicit at the type level. The summary:
 
 ### What's new
 
@@ -66,7 +76,7 @@ are **byte-identical** to pre-1.4 for any UTC moment. No change for those.
 
 ### Step-by-step migration
 
-1. Bump to `1.4.0`. Build the app.
+1. Bump to `1.4.1`. Build the app.
 2. Audit IDE warnings on `formatLocalDateTime`, `parseLocalDateTime`, and direct uses of
    `SERVER_PATTERN_FULL`. For each call site, decide:
    - **Server I/O** (the field represents a moment in time): migrate the field type to
@@ -148,7 +158,7 @@ val fileString = localDateTime.toFileString()
 ```
 
 > [!IMPORTANT]
-> **Wire format change in 1.4.0.** The naive format helpers (and any path routing through
+> **Wire format change in 1.4.1.** The naive format helpers (and any path routing through
 > them — `LocalDateTime.toJsonString()`, `DateTimeSerializer`, `localDateTimeToJson` Room
 > converter) now emit `2025-05-29T10:38:29.000000` (no `Z`) where pre-1.4 they emitted
 > `2025-05-29T10:38:29.000000Z`. The honest no-zone format reflects what `LocalDateTime`

--- a/DateHelperUtil/src/main/java/uk/co/appoly/droid/util/DateHelper.kt
+++ b/DateHelperUtil/src/main/java/uk/co/appoly/droid/util/DateHelper.kt
@@ -303,7 +303,7 @@ object DateHelper {
 	 * Delegates to [formatNaiveDateTime] — does not enforce UTC. For server I/O,
 	 * prefer [formatServerTimestamp] with an [Instant] / [ZonedDateTime].
 	 *
-	 * @return Formatted date-time string using [SERVER_PATTERN_FULL] or null if the receiver is null
+	 * @return Formatted date-time string using [NAIVE_PATTERN_FULL] or null if the receiver is null
 	 */
 	fun LocalDateTime?.toJsonString(): String? {
 		return formatNaiveDateTime(this)
@@ -361,7 +361,7 @@ object DateHelper {
 	}
 
 	/**
-	 * Formats an [Instant] for transmission to the server using [SERVER_PATTERN_FULL].
+	 * Formats an [Instant] for transmission to the server using [SERVER_PATTERN_FULL_OFFSET].
 	 *
 	 * Because [Instant] is UTC by definition and the formatter is pinned to UTC via
 	 * [serverFormatterUtc], the emitted digits are *guaranteed* to be UTC wall-clock —
@@ -377,7 +377,7 @@ object DateHelper {
 		instant?.let { serverFormatterUtc.format(it) }
 
 	/**
-	 * Formats a [ZonedDateTime] for transmission to the server using [SERVER_PATTERN_FULL].
+	 * Formats a [ZonedDateTime] for transmission to the server using [SERVER_PATTERN_FULL_OFFSET].
 	 *
 	 * The zone is collapsed to an [Instant] before formatting, so the emitted digits are UTC
 	 * regardless of the input zone. Equivalent to `formatServerTimestamp(zoned?.toInstant())`.

--- a/DateHelperUtil/src/main/java/uk/co/appoly/droid/util/DateHelper.kt
+++ b/DateHelperUtil/src/main/java/uk/co/appoly/droid/util/DateHelper.kt
@@ -391,24 +391,45 @@ object DateHelper {
 	/**
 	 * Parses a server-emitted timestamp into an [Instant].
 	 *
-	 * The wire format follows [SERVER_PATTERN_FULL_OFFSET] — microsecond precision plus a real
-	 * ISO-8601 offset designator. `Z`, `+00:00`, `+01:00`, `-05:00` are all valid input; the
-	 * returned [Instant] represents the same moment regardless of which offset the server
+	 * The recommended wire format is [SERVER_PATTERN_FULL_OFFSET] — microsecond precision plus a
+	 * real ISO-8601 offset designator. `Z`, `+00:00`, `+01:00`, `-05:00` are all valid input;
+	 * the returned [Instant] represents the same moment regardless of which offset the server
 	 * chose. Once parsed, the [Instant] carries UTC at the type level — it cannot be silently
 	 * reinterpreted as device-local downstream.
 	 *
-	 * Backward compatibility: `Z` was previously the only accepted suffix; it remains so by
-	 * construction. The parser is now strictly more lenient.
+	 * Fallback for zone-naive server output: if the input does not match
+	 * [SERVER_PATTERN_FULL_OFFSET], the parser falls back to [SERVER_PATTERN_SHORT]
+	 * (`yyyy-MM-dd HH:mm:ss`) and **treats the digits as UTC**. This matches what pre-1.4
+	 * [parseLocalDateTime] did downstream of the [ZonedDateTimeSerializer], and keeps
+	 * Carbon/Laravel-style backends (which emit `"2025-12-01 10:38:29"` by default for
+	 * `created_at` / `updated_at` etc.) parseable without forcing a server-side change.
 	 *
-	 * @param text String representation of the server timestamp (e.g., "2023-12-01T10:38:29.000000Z")
+	 * Backward compatibility: `Z` was the only accepted suffix pre-1.4; it still parses. Any
+	 * explicit ISO-8601 offset parses. The short Carbon format now also parses (1.4.1+) — this
+	 * restores the pre-1.4 `ZonedDateTimeSerializer.deserialize` tolerance that 1.4.0 lost.
+	 *
+	 * @param text String representation of the server timestamp (e.g., "2023-12-01T10:38:29.000000Z"
+	 *   or the Carbon-style "2023-12-01 10:38:29")
 	 * @return Parsed [Instant], or null if the input is null, blank, or cannot be parsed
 	 */
 	fun parseServerInstant(text: String?): Instant? {
 		if (text.isNullOrBlank()) return null
-		return try {
-			OffsetDateTime.parse(text, serverParserOffset).toInstant()
+
+		// 1. Strict ISO-8601 with offset designator (recommended path).
+		try {
+			return OffsetDateTime.parse(text, serverParserOffset).toInstant()
 		} catch (e: Exception) {
-			DateHelperLog.e(this, "parseServerInstant: failed to parse \"$text\" with SERVER_PATTERN_FULL_OFFSET", e)
+			DateHelperLog.d(this, "parseServerInstant: \"$text\" not in SERVER_PATTERN_FULL_OFFSET, trying SERVER_PATTERN_SHORT (as UTC)", e)
+		}
+
+		// 2. Carbon/Laravel short format ("yyyy-MM-dd HH:mm:ss") — treat as UTC.
+		//    Restores pre-1.4 ZonedDateTimeSerializer tolerance for naive server timestamps.
+		return try {
+			LocalDateTime
+				.parse(text, DateTimeFormatter.ofPattern(SERVER_PATTERN_SHORT))
+				.toInstant(ZoneOffset.UTC)
+		} catch (e: Exception) {
+			DateHelperLog.e(this, "parseServerInstant: failed to parse \"$text\" with any known format", e)
 			null
 		}
 	}
@@ -416,29 +437,20 @@ object DateHelper {
 	/**
 	 * Parses a server-emitted timestamp into a [ZonedDateTime] in UTC.
 	 *
-	 * Convenience over [parseServerInstant] for the common case where the caller wants a
-	 * [ZonedDateTime] rather than a raw [Instant]. The returned value **always carries the
-	 * UTC zone** — regardless of whether the input used `Z`, `+00:00`, `+01:00`, `-05:00`,
-	 * or any other ISO-8601 offset, the resulting `ZonedDateTime` represents the same
-	 * moment expressed in UTC. To shift it into the device's local zone, chain
-	 * [toDeviceZone] from `DateHelperExtensions`.
+	 * Convenience wrapper over [parseServerInstant] for callers that want a [ZonedDateTime]
+	 * rather than a raw [Instant]. The returned value **always carries the UTC zone** —
+	 * regardless of whether the input used `Z`, `+00:00`, `+01:00`, `-05:00`, any other
+	 * ISO-8601 offset, or the zone-naive Carbon short form, the resulting `ZonedDateTime`
+	 * represents the same moment expressed in UTC. To shift it into the device's local zone,
+	 * chain [toDeviceZone] from `DateHelperExtensions`.
 	 *
-	 * Accepts the same input formats as [parseServerInstant]; the wire format is
-	 * [SERVER_PATTERN_FULL_OFFSET].
+	 * Accepts the same input formats as [parseServerInstant]; the recommended wire format is
+	 * [SERVER_PATTERN_FULL_OFFSET]. See [parseServerInstant] for the full fallback chain.
 	 *
-	 * @param text String representation of the server timestamp (e.g., "2023-12-01T10:38:29.000000Z")
+	 * @param text String representation of the server timestamp (e.g., "2023-12-01T10:38:29.000000Z"
+	 *   or the Carbon-style "2023-12-01 10:38:29")
 	 * @return Parsed [ZonedDateTime] in UTC, or null if the input is null, blank, or cannot be parsed
 	 */
-	fun parseServerZoneDateTime(text: String?): ZonedDateTime? {
-		if (text.isNullOrBlank()) return null
-		return try {
-			OffsetDateTime
-				.parse(text, serverParserOffset)
-				.toInstant()
-				.atZone(ZoneOffset.UTC)
-		} catch (e: Exception) {
-			DateHelperLog.e(this, "parseServerZoneDateTime: failed to parse \"$text\" with SERVER_PATTERN_FULL_OFFSET", e)
-			null
-		}
-	}
+	fun parseServerZoneDateTime(text: String?): ZonedDateTime? =
+		parseServerInstant(text)?.atZone(ZoneOffset.UTC)
 }

--- a/DateHelperUtil/src/test/java/uk/co/appoly/droid/util/DateHelperServerTimestampTest.kt
+++ b/DateHelperUtil/src/test/java/uk/co/appoly/droid/util/DateHelperServerTimestampTest.kt
@@ -179,6 +179,33 @@ class DateHelperServerTimestampTest {
 		assertEquals(expected, parsed)
 	}
 
+	// 1.4.1 regression coverage: Carbon/Laravel-style short timestamps were tolerated by the
+	// pre-1.4 ZonedDateTimeSerializer (via parseLocalDateTime → SERVER_PATTERN_SHORT fallback).
+	// 1.4.0 lost that tolerance; 1.4.1 restores it inside parseServerInstant so the same
+	// inputs keep working against Carbon-style backends.
+
+	@Test
+	fun `parseServerInstant accepts Carbon short format and treats digits as UTC`() {
+		val parsed = DateHelper.parseServerInstant("2025-05-29 10:38:29")
+		val expected = LocalDateTime.of(2025, 5, 29, 10, 38, 29).toInstant(ZoneOffset.UTC)
+		assertEquals(expected, parsed)
+	}
+
+	@Test
+	fun `parseServerInstant short format is independent of device timezone`() {
+		val text = "2025-05-29 10:38:29"
+		val expected = LocalDateTime.of(2025, 5, 29, 10, 38, 29).toInstant(ZoneOffset.UTC)
+
+		TimeZone.setDefault(TimeZone.getTimeZone("Europe/London")) // BST in May
+		assertEquals(expected, DateHelper.parseServerInstant(text))
+
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Tokyo"))
+		assertEquals(expected, DateHelper.parseServerInstant(text))
+
+		TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+		assertEquals(expected, DateHelper.parseServerInstant(text))
+	}
+
 	// endregion
 
 	// region parseServerZoneDateTime(String?)
@@ -259,6 +286,16 @@ class DateHelperServerTimestampTest {
 		val viaWrapper = DateHelper.parseServerZoneDateTime(text)
 		val viaInstant = DateHelper.parseServerInstant(text)?.atZone(ZoneOffset.UTC)
 		assertEquals(viaInstant, viaWrapper)
+	}
+
+	@Test
+	fun `parseServerZoneDateTime accepts Carbon short format and returns UTC ZonedDateTime`() {
+		// 1.4.1 regression coverage — restores pre-1.4 ZonedDateTimeSerializer behaviour
+		// for naive Carbon/Laravel-style server timestamps.
+		val parsed = DateHelper.parseServerZoneDateTime("2025-05-29 10:38:29")
+		val expected = LocalDateTime.of(2025, 5, 29, 10, 38, 29).atZone(ZoneOffset.UTC)
+		assertEquals(expected, parsed)
+		assertEquals(ZoneOffset.UTC, parsed!!.zone)
 	}
 
 	@Test

--- a/LazyGridPagingExtensions/README.md
+++ b/LazyGridPagingExtensions/README.md
@@ -15,8 +15,8 @@ Extension functions for integrating Jetpack Paging 3 with Compose LazyVerticalGr
 
 ```gradle.kts
 // Requires the base PagingExtensions module
-implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyGridPagingExtensions:1.4.1")
 
 // Make sure to include Jetpack Paging Compose
 implementation("androidx.paging:paging-compose:3.5.0")

--- a/LazyListPagingExtensions/README.md
+++ b/LazyListPagingExtensions/README.md
@@ -15,8 +15,8 @@ Extension functions for easy integration of Jetpack Paging 3 with Compose LazyCo
 
 ```gradle.kts
 // Requires the base PagingExtensions module
-implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.4.0")
-implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.4.1")
+implementation("com.github.appoly.AppolyDroid-Toolbox:LazyListPagingExtensions:1.4.1")
 
 // Make sure to include Jetpack Paging Compose
 implementation("androidx.paging:paging-compose:3.5.0")

--- a/MockInterceptor-AppolyJson/README.md
+++ b/MockInterceptor-AppolyJson/README.md
@@ -14,7 +14,7 @@ Extension for [MockInterceptor-Serialization](../MockInterceptor-Serialization/)
 
 ```gradle.kts
 // MockInterceptor and MockInterceptor-Serialization are included transitively
-implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-AppolyJson:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-AppolyJson:1.4.1")
 ```
 
 ## Usage

--- a/MockInterceptor-Retrofit/README.md
+++ b/MockInterceptor-Retrofit/README.md
@@ -13,7 +13,7 @@ Extension for [MockInterceptor](../MockInterceptor/) that reads Retrofit HTTP an
 
 ```gradle.kts
 // MockInterceptor is included transitively
-implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-Retrofit:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-Retrofit:1.4.1")
 ```
 
 > **Note:** Retrofit is a `compileOnly` dependency — your project must already depend on Retrofit.

--- a/MockInterceptor-Serialization/README.md
+++ b/MockInterceptor-Serialization/README.md
@@ -12,7 +12,7 @@ Extension for [MockInterceptor](../MockInterceptor/) that adds type-safe JSON re
 
 ```gradle.kts
 // MockInterceptor is included transitively
-implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-Serialization:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor-Serialization:1.4.1")
 ```
 
 ## Usage

--- a/MockInterceptor/README.md
+++ b/MockInterceptor/README.md
@@ -16,7 +16,7 @@ An OkHttp interceptor with a route-matching DSL for mocking API responses during
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:MockInterceptor:1.4.1")
 ```
 
 ## Usage

--- a/PagingExtensions/README.md
+++ b/PagingExtensions/README.md
@@ -12,7 +12,7 @@ Core utilities and extensions for Jetpack Paging 3 integration, providing the fo
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:PagingExtensions:1.4.1")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In your `libs.versions.toml` file:
 
 ```toml
 [versions]
-appolydroidToolbox = "1.4.0" # Replace with the latest version
+appolydroidToolbox = "1.4.1" # Replace with the latest version
 
 [libraries]
 appolydroid-toolbox-bom = { group = "com.github.appoly.AppolyDroid-Toolbox", name = "AppolyDroid-Toolbox-bom", version.ref = "appolydroidToolbox" }
@@ -126,7 +126,7 @@ In your module's `build.gradle.kts`:
 ```gradle.kts
 dependencies {
     // Import the BOM
-    implementation(platform("com.github.appoly.AppolyDroid-Toolbox:AppolyDroid-Toolbox-bom:1.4.0"))
+    implementation(platform("com.github.appoly.AppolyDroid-Toolbox:AppolyDroid-Toolbox-bom:1.4.1"))
 
     // Now you can use AppolyDroid modules without specifying versions
     implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo")
@@ -162,7 +162,7 @@ In your `libs.versions.toml` file:
 
 ```toml
 [versions]
-appolydroidToolbox = "1.4.0" # Replace with the latest version
+appolydroidToolbox = "1.4.1" # Replace with the latest version
 
 [libraries]
 #AppolyDroid-Toolbox
@@ -228,7 +228,7 @@ In your module's `build.gradle.kts`:
 
 ```gradle.kts
 dependencies {
-    val appolydroidToolbox = "1.4.0" // Replace with the latest version
+    val appolydroidToolbox = "1.4.1" // Replace with the latest version
     // Add only the modules you need
     implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo:$appolydroidToolbox")
     implementation("com.github.appoly.AppolyDroid-Toolbox:BaseRepo-AppolyJson:$appolydroidToolbox")

--- a/S3Uploader-Multipart/README.md
+++ b/S3Uploader-Multipart/README.md
@@ -16,7 +16,7 @@ Advanced S3 upload module with pause, resume, and recovery support using AWS S3 
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader-Multipart:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader-Multipart:1.4.1")
 ```
 
 This module depends on `S3Uploader` and includes it transitively.

--- a/S3Uploader/README.md
+++ b/S3Uploader/README.md
@@ -16,7 +16,7 @@ Standalone module for Amazon S3 file uploading with progress tracking and error 
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:S3Uploader:1.4.1")
 ```
 
 ## Usage

--- a/SegmentedControl/README.md
+++ b/SegmentedControl/README.md
@@ -17,7 +17,7 @@ A highly customizable iOS-style segmented control for Jetpack Compose with smoot
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:SegmentedControl:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:SegmentedControl:1.4.1")
 ```
 
 ## Usage

--- a/UiState/README.md
+++ b/UiState/README.md
@@ -13,7 +13,7 @@ A standardized UI state management library for Android applications, providing c
 ## Installation
 
 ```gradle.kts
-implementation("com.github.appoly.AppolyDroid-Toolbox:UiState:1.4.0")
+implementation("com.github.appoly.AppolyDroid-Toolbox:UiState:1.4.1")
 ```
 
 ## Usage

--- a/buildSrc/src/main/kotlin/BuildConfig.kt
+++ b/buildSrc/src/main/kotlin/BuildConfig.kt
@@ -9,7 +9,7 @@ object BuildConfig {
      * The current version of the AppolyDroid Toolbox library.
      * This is used for maven publishing and README version updates.
      */
-	const val TOOLBOX_VERSION = "1.4.0"
+	const val TOOLBOX_VERSION = "1.4.1"
 
     /**
      * SDK version configuration for Android modules.


### PR DESCRIPTION
## Summary

- Restores `yyyy-MM-dd HH:mm:ss` tolerance to `parseServerInstant` (and therefore `parseServerZoneDateTime`, and therefore `ZonedDateTimeSerializer` / `NullableZonedDateTimeSerializer`). The pre-1.4 path tolerated Carbon/Laravel-style timestamps via `parseLocalDateTime`'s `SERVER_PATTERN_SHORT` fallback; 1.4.0 dropped that, breaking any app consuming a PHP-style backend (every `created_at`, `updated_at`, `last_logged_in` etc. would `DateTimeParseException` on parse).
- Wire format on the way **out** is unchanged. Only reads are affected, and only to be more lenient.

## Behaviour change

`parseServerInstant`:
1. Try `SERVER_PATTERN_FULL_OFFSET` (recommended, unchanged).
2. If that fails, try `SERVER_PATTERN_SHORT` (`yyyy-MM-dd HH:mm:ss`) and treat digits as UTC.

`parseServerZoneDateTime` is now a thin wrapper over `parseServerInstant` (DRY — they always shared semantics).

## Why "treat as UTC"

Matches what pre-1.4 effectively did: the 1.3.x `ZonedDateTimeSerializer.deserialize` called `parseLocalDateTime` (short fallback) → `.atZone(ZoneOffset.UTC).toDeviceZone()`. Laravel/Carbon's default Carbon serializer emits timestamps in the server's configured timezone (typically UTC for production deployments); treating zone-naive digits as UTC is the established convention this library was using before.

## Tests

3 new cases on the existing `DateHelperServerTimestampTest`:
- `parseServerInstant accepts Carbon short format and treats digits as UTC`
- `parseServerInstant short format is independent of device timezone`
- `parseServerZoneDateTime accepts Carbon short format and returns UTC ZonedDateTime`

All existing tests still pass (no behaviour change for ISO-8601-with-offset input).

## Docs

- New "1.4.1 patch note" section at the top of `DateHelperUtil/README.md` calling out the regression and the fix.
- `Migrating from 1.3.x` heading updated to reference 1.4.1.
- Sibling README dependency snippets bumped across the repo.

## Upgrade guidance

- **Apps on 1.4.0 without Carbon backends**: no action needed; 1.4.1 changes nothing observable.
- **Apps stuck on 1.3.x because of this regression**: bump straight to 1.4.1.
- **1.4.0 is superseded** for the 1.4 line — recommend skipping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)